### PR TITLE
Target servers by name for mup actions

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,21 +1,25 @@
 name: "MUP Deploy"
 description: "Deploy a Meteor application using Meteor Up"
 inputs:
-    mode:
-        description: 'The MUP script to run. Either "DEPLOY", "SETUP", or "RESTART"'
-        required: true
-    meteor_deploy_path:
-        description: "The relative path to Meteor's .deploy directory"
-        required: true
-    package_manager:
-        description: 'The node package manager to use. Either "NPM" or "YARN"'
-        required: true
-    project_path:
-        description: "The path to the folder that contains the package.json for the Meteor app. Defaults to the current directory."
-        required: false
-        default: "."
+  mode:
+    description: 'The MUP script to run. Either "DEPLOY", "SETUP", or "RESTART"'
+    required: true
+  meteor_deploy_path:
+    description: "The relative path to Meteor's .deploy directory"
+    required: true
+  package_manager:
+    description: 'The node package manager to use. Either "NPM" or "YARN"'
+    required: true
+  project_path:
+    description: "The path to the folder that contains the package.json for the Meteor app. Defaults to the current directory."
+    required: false
+    default: "."
+  servers:
+    description: "Comma separated server names for the action to target. Ex: 'one,two'"
+    required: false
+    default: ""
 runs:
-    using: "composite"
-    steps:
-        - run: chmod +x ${{github.action_path}}/script.sh && sh ${{github.action_path}}/script.sh ${{ inputs.mode }} ${{ inputs.meteor_deploy_path }} ${{ inputs.package_manager }} ${{ github.workspace }} ${{ inputs.project_path }}
-          shell: bash
+  using: "composite"
+  steps:
+    - run: chmod +x ${{github.action_path}}/script.sh && sh ${{github.action_path}}/script.sh ${{ inputs.mode }} ${{ inputs.meteor_deploy_path }} ${{ inputs.package_manager }} ${{ github.workspace }} ${{ inputs.project_path }}
+      shell: bash

--- a/script.sh
+++ b/script.sh
@@ -51,9 +51,7 @@ cd ~/
 
 # Install meteor
 echo "Installing Meteor..."
-# Using version 2.12 temporarily due to this issue - https://github.com/meteor/meteor/issues/12771
-# Need to change back to https://install.meteor.com/ when resolved to stay on the latest version
-curl https://install.meteor.com\?release=2.12 | sh
+curl https://install.meteor.com\ | sh
 export METEOR_ALLOW_SUPERUSER=true
 
 # Go to the project

--- a/script.sh
+++ b/script.sh
@@ -5,11 +5,14 @@
 # Second parameter is the meteor deploy path
 # Third parameter is the node package manager to use. Either "NPM" or "YARN"
 # Fourth parameter is the absolute path of the repository
+# fifth parameter is the folder that contains the package.json for the Meteor app. Defaults to the current directory.
+# sixth parameter is a string of comma separated server names for the action to target. Ex: 'one,two'
 mode=$1;
 meteor_deploy_path=$2;
 node_package_manager=$3
 repository_path=$4
 project_path=$5
+servers=$6
 
 echo "Running MUP GitHub action..."
 
@@ -35,6 +38,12 @@ fi
 if [ "${repository_path}" = "" ]; then
 	echo "Invalid repository path passed!"
 	exit 1
+fi
+
+servers_option=""
+
+if [ "${servers}" != "" ]; then
+    servers_option="--servers ${servers}"
 fi
 
 # Go to the root level
@@ -72,11 +81,11 @@ cd $meteor_deploy_path
 # Running specified command
 if [ "${mode}" = "DEPLOY" ]; then
 	echo "Deploying using config from ${meteor_deploy_path}..."
-	mup deploy --verbose
+	mup deploy --verbose "$servers_option"
 elif [ "${mode}" = "SETUP" ]; then
 	echo "Setting up using config from ${meteor_deploy_path}..."
-	mup setup --verbose
+	mup setup --verbose "$servers_option"
 elif [ "${mode}" = "RESTART" ]; then
 	echo "Restarting..."
-	mup restart
+	mup restart "$servers_option"
 fi


### PR DESCRIPTION
1. Add an option to pass a comma separated list of server names (as listed in mup.js `app.servers`). 
2. Install meteor with default url to get latest version instead of specifying a specific version name due to this [issue](https://github.com/meteor/meteor/issues/12771)