### PR TITLE
Only use a single server name in --options

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -14,12 +14,12 @@ inputs:
     description: "The path to the folder that contains the package.json for the Meteor app. Defaults to the current directory."
     required: false
     default: "."
-  servers:
-    description: "Comma separated server names for the action to target. Ex: 'one,two'"
+  server:
+    description: "Name of the individual server for the action to target. Example: two"
     required: false
     default: ""
 runs:
   using: "composite"
   steps:
-    - run: chmod +x ${{github.action_path}}/script.sh && sh ${{github.action_path}}/script.sh ${{ inputs.mode }} ${{ inputs.meteor_deploy_path }} ${{ inputs.package_manager }} ${{ github.workspace }} ${{ inputs.project_path }} ${{ inputs.servers }}
+    - run: chmod +x ${{github.action_path}}/script.sh && sh ${{github.action_path}}/script.sh ${{ inputs.mode }} ${{ inputs.meteor_deploy_path }} ${{ inputs.package_manager }} ${{ github.workspace }} ${{ inputs.project_path }} ${{ inputs.server }}
       shell: bash

--- a/script.sh
+++ b/script.sh
@@ -6,13 +6,13 @@
 # Third parameter is the node package manager to use. Either "NPM" or "YARN"
 # Fourth parameter is the absolute path of the repository
 # fifth parameter is the folder that contains the package.json for the Meteor app. Defaults to the current directory.
-# sixth parameter is a string of comma separated server names for the action to target. Ex: 'one,two'
+# sixth parameter is a string of the name of the server for the action to target. Example: two
 mode=$1;
 meteor_deploy_path=$2;
 node_package_manager=$3
 repository_path=$4
 project_path=$5
-servers=$6
+server=$6
 
 echo "Running MUP GitHub action..."
 
@@ -42,8 +42,8 @@ fi
 
 servers_option=""
 
-if [ "${servers}" != "" ]; then
-    servers_option="--servers ${servers}"
+if [ "${server}" != "" ]; then
+    servers_option="--servers ${server}"
 fi
 
 # Go to the root level


### PR DESCRIPTION
Issue
Attempting to run actions on more than 1 server with the --servers option did not work. But deploying to a single server did. I updated the inputs and descriptions to reflect that only 1 server name should be passed in. 

